### PR TITLE
Add experiment for MFCC Autoencoder to determine best (n_timb, n_hid)

### DIFF
--- a/Timbre Encoder.ipynb
+++ b/Timbre Encoder.ipynb
@@ -159,12 +159,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "**Comment one of these li"
+    "**Comment one of these lines**"
    ]
   },
   {
@@ -456,7 +454,7 @@
     "n_hid = 12; n_timb = 4; lr = 1e-3; n_epochs = 5000; batch_size=22272\n",
     "\n",
     "# Training model \n",
-    "model = TimbreVAE(n_mfcc=n_mfcc, n_hid=n_hid, n_timb=n_timb, n_vowels=n_vowels)\n",
+    "model = TimbreVAE(n_mfcc=n_mfcc, n_hid=n_hid, n_timb=n_timb)\n",
     "\n",
     "# Define loss - from pytorch VAE example.\n",
     "def loss_fn(recon_x, x, mu, logvar):\n",
@@ -549,6 +547,759 @@
     "data_idx = flat_data_idx(wav_idx, 30)\n",
     "label = data_tensor[data_idx]\n",
     "pred = model(data_tensor[data_idx])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Experiment: Choosing `n_hid`, `n_timb`\n",
+    "\n",
+    "From running this, we find the results:\n",
+    "Best `n_hid`: 12, Best `n_timb`: 14"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "65d296f7d35d4c74acf7f46dab5925ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 6, n_timb: 4', max=2500.0, style=ProgressStyle(des…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 6, n_timb: 4, Final val loss: 12.756245229436063, Time taken: 24.036638021469116\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_6_4_12.756245229436063.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "637a70bd5180424cb248d25fc7782aef",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 8, n_timb: 4', max=2500.0, style=ProgressStyle(des…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 8, n_timb: 4, Final val loss: 12.756556719198993, Time taken: 23.402870178222656\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_8_4_12.756556719198993.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4631374efbbf4dd393a26627aaf5e0b3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 8, n_timb: 6', max=2500.0, style=ProgressStyle(des…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 8, n_timb: 6, Final val loss: 12.757583793552442, Time taken: 24.187214136123657\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_8_6_12.757583793552442.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1234f6522da7490f8fea6ba030324f82",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 10, n_timb: 4', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 10, n_timb: 4, Final val loss: 12.755354256465518, Time taken: 23.62875461578369\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_10_4_12.755354256465518.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bffe0fb4c21e4813a77fe5e903c54b2b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 10, n_timb: 6', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 10, n_timb: 6, Final val loss: 12.756701239224139, Time taken: 23.57104468345642\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_10_6_12.756701239224139.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ce3ffe45c5104ad68621a431a255b167",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 10, n_timb: 8', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 10, n_timb: 8, Final val loss: 12.75628732264727, Time taken: 23.87569832801819\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_10_8_12.75628732264727.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7cfdae241df14f52b49ad43e45a25f13",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 12, n_timb: 4', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 12, n_timb: 4, Final val loss: 12.75652725395115, Time taken: 23.377437353134155\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_12_4_12.75652725395115.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "24bdd35cf8da4354b09ed4e8ef78ad9a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 12, n_timb: 6', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 12, n_timb: 6, Final val loss: 12.756516029094827, Time taken: 24.132755041122437\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_12_6_12.756516029094827.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "80524de2ec654ee5acf77ad615f62c09",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 12, n_timb: 8', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 12, n_timb: 8, Final val loss: 12.757957020025144, Time taken: 21.46918272972107\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_12_8_12.757957020025144.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7bcd9d9a0a3343c9a7652928ae3ff05c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 12, n_timb: 10', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 12, n_timb: 10, Final val loss: 12.757127783764368, Time taken: 24.31379532814026\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_12_10_12.757127783764368.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ba8c7d87690647749f976883fcee2983",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 14, n_timb: 4', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 14, n_timb: 4, Final val loss: 12.75653426948635, Time taken: 23.120083808898926\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_14_4_12.75653426948635.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "549a86014cec4551b236af68296f1858",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 14, n_timb: 6', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 14, n_timb: 6, Final val loss: 12.75579904139727, Time taken: 23.299814462661743\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_14_6_12.75579904139727.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a1f86b8c40f744bbb90b1b531ebcb35a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 14, n_timb: 8', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 14, n_timb: 8, Final val loss: 12.757596421515805, Time taken: 24.524491548538208\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_14_8_12.757596421515805.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "277dd35e7e734f41aa39c29bc911df44",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 14, n_timb: 10', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 14, n_timb: 10, Final val loss: 12.756250841864224, Time taken: 24.066789388656616\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_14_10_12.756250841864224.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ddccc7066410466cbdd1f752cbcedcfd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 14, n_timb: 12', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 14, n_timb: 12, Final val loss: 12.757847577676007, Time taken: 23.379464149475098\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_14_12_12.757847577676007.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f77a68e0d1ad433f9c96b54812956090",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 16, n_timb: 4', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 16, n_timb: 4, Final val loss: 12.75629153196839, Time taken: 23.141919136047363\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_16_4_12.75629153196839.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a29807120aed403587af8f2212b5cfa0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 16, n_timb: 6', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 16, n_timb: 6, Final val loss: 12.75677841011135, Time taken: 23.408835649490356\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_16_6_12.75677841011135.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9fbd525a318d4eb3858a38987e7fbc5b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 16, n_timb: 8', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 16, n_timb: 8, Final val loss: 12.757703057650861, Time taken: 23.205310583114624\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_16_8_12.757703057650861.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "164ad8405d7141fc9240f6a1c2167747",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 16, n_timb: 10', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 16, n_timb: 10, Final val loss: 12.756217167295258, Time taken: 18.973145723342896\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_16_10_12.756217167295258.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eb355397ada040c6a7f8bf467ec87881",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 16, n_timb: 12', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 16, n_timb: 12, Final val loss: 12.756746138649426, Time taken: 18.91083335876465\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_16_12_12.756746138649426.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4e6f9708fc6b43bea0f2924e35c104b0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 16, n_timb: 14', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 16, n_timb: 14, Final val loss: 12.757397180316092, Time taken: 19.097800970077515\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_16_14_12.757397180316092.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1b581abac8004f38b745c698ece54d8d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 18, n_timb: 4', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 18, n_timb: 4, Final val loss: 12.756252244971265, Time taken: 18.403200149536133\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_18_4_12.756252244971265.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a5c5069a36242f096ed402dba273109",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 18, n_timb: 6', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 18, n_timb: 6, Final val loss: 12.755765366828305, Time taken: 20.536202669143677\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_18_6_12.755765366828305.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ff8c0252adfb4320b68b49d0684bb304",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 18, n_timb: 8', max=2500.0, style=ProgressStyle(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 18, n_timb: 8, Final val loss: 12.756218570402298, Time taken: 18.79640245437622\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_18_8_12.756218570402298.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "785fe56719e345f5b9911198c0e7a7da",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 18, n_timb: 10', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 18, n_timb: 10, Final val loss: 12.757287737966953, Time taken: 19.083486557006836\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_18_10_12.757287737966953.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "69588899cbf04340b123a9f65a4a3c65",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 18, n_timb: 12', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 18, n_timb: 12, Final val loss: 12.757718491828305, Time taken: 19.04806160926819\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_18_12_12.757718491828305.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "39afd0e0656a482c94401b5f7a4a7caf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 18, n_timb: 14', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 18, n_timb: 14, Final val loss: 12.75823904454023, Time taken: 19.794686317443848\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_18_14_12.75823904454023.pt\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "98b3e05805e848aa9c6decf75e2f9a47",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='n_hid: 18, n_timb: 16', max=2500.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "n_hid: 18, n_timb: 16, Final val loss: 12.756389749461206, Time taken: 18.548084497451782\n",
+      "Model saved at model_data\\TimbreVAE_n_hid_n_timb_experiment_18_16_12.756389749461206.pt\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Define loss - from pytorch VAE example.\n",
+    "def loss_fn(recon_x, x, mu, logvar):\n",
+    "    BCE = F.binary_cross_entropy(recon_x, x, reduction='sum')\n",
+    "    KLD = -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp())\n",
+    "    return BCE + KLD\n",
+    "\n",
+    "n_hid_candidates = [6, 8, 10, 12, 14, 16, 18]\n",
+    "n_timb_candidates = [4, 6, 8, 10, 12, 14, 16]\n",
+    "lr = 1e-3; n_epochs = 2500; batch_size=22272\n",
+    "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
+    "\n",
+    "losses = []\n",
+    "for hid_idx in range(len(n_hid_candidates)):\n",
+    "    for timb_idx in range(len(n_timb_candidates)):\n",
+    "        if (hid_idx < timb_idx): continue\n",
+    "        n_hid = n_hid_candidates[hid_idx]\n",
+    "        n_timb = n_timb_candidates[timb_idx]\n",
+    "        \n",
+    "        # Training model \n",
+    "        model = TimbreVAE(n_mfcc=n_mfcc, n_hid=n_hid, n_timb=n_timb)\n",
+    "\n",
+    "        X_train = X_train.to(device)\n",
+    "        X_val = X_val.to(device)\n",
+    "        model.to(device) \n",
+    "        # opt = optim.SGD(model.parameters(), lr=lr)\n",
+    "        opt = optim.Adam(model.parameters(), lr=lr)\n",
+    "\n",
+    "        # Fit the model\n",
+    "        tic = time.time()\n",
+    "        loss, val_loss = model.train_func(X_train, X_val, model, opt, loss_fn, batch_size=batch_size,\n",
+    "                                epochs=n_epochs, print_graph=False, desc=\"n_hid: {}, n_timb: {}\".format(n_hid, n_timb))\n",
+    "        toc = time.time()\n",
+    "        print('n_hid: {}, n_timb: {}, Final val loss: {}, Time taken: {}'.format(n_hid, n_timb, val_loss, toc - tic))\n",
+    "        model_path = os.path.join(\"model_data\", \"TimbreVAE_n_hid_n_timb_experiment_{}_{}_{}.pt\"\n",
+    "                                  .format(n_hid, n_timb, val_loss))\n",
+    "        torch.save(model.state_dict(), model_path)\n",
+    "        print(\"Model saved at {}\".format(model_path)) \n",
+    "        losses.append(val_loss)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best n_hid: 12, Best n_timb: 14\n",
+      "[[12.756245229436063 list([6, 4])]\n",
+      " [12.756556719198993 list([6, 6])]\n",
+      " [12.757583793552442 list([6, 8])]\n",
+      " [12.755354256465518 list([6, 10])]\n",
+      " [12.756701239224139 list([6, 12])]\n",
+      " [12.75628732264727 list([6, 14])]\n",
+      " [12.75652725395115 list([6, 16])]\n",
+      " [12.756516029094827 list([8, 4])]\n",
+      " [12.757957020025144 list([8, 6])]\n",
+      " [12.757127783764368 list([8, 8])]\n",
+      " [12.75653426948635 list([8, 10])]\n",
+      " [12.75579904139727 list([8, 12])]\n",
+      " [12.757596421515805 list([8, 14])]\n",
+      " [12.756250841864224 list([8, 16])]\n",
+      " [12.757847577676007 list([10, 4])]\n",
+      " [12.75629153196839 list([10, 6])]\n",
+      " [12.75677841011135 list([10, 8])]\n",
+      " [12.757703057650861 list([10, 10])]\n",
+      " [12.756217167295258 list([10, 12])]\n",
+      " [12.756746138649426 list([10, 14])]\n",
+      " [12.757397180316092 list([10, 16])]\n",
+      " [12.756252244971265 list([12, 4])]\n",
+      " [12.755765366828305 list([12, 6])]\n",
+      " [12.756218570402298 list([12, 8])]\n",
+      " [12.757287737966953 list([12, 10])]\n",
+      " [12.757718491828305 list([12, 12])]\n",
+      " [12.75823904454023 list([12, 14])]\n",
+      " [12.756389749461206 list([12, 16])]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "indices = [ [n_hid_candidates[hid_idx], n_timb_candidates[timb_idx]] \n",
+    "            for hid_idx in range(len(n_hid_candidates))\n",
+    "            for timb_idx in range(len(n_timb_candidates))]\n",
+    "best_hid, best_timb = indices[np.argmax(np.array(losses))]\n",
+    "print(\"Best n_hid: {}, Best n_timb: {}\".format(best_hid, best_timb))\n",
+    "print(np.array(list(zip(losses, indices))))"
    ]
   },
   {


### PR DESCRIPTION
It was determined that the best `n_hid` and `n_timb` to use for the MFCC autoencoder (`TimbreVAE`) is `n_hid`: 10, `n_timb`: 4.

For future reference (e.g. if we are plotting graph in future), the notebook output is preserved with the loss values for this experiment.

Experiments run with: 
- `lr = 1e-3`
- `n_epochs = 2500`
- `batch_size=22272` (full size)
- `n_mfcc=20` (In the future we may try other numbers)
- `n_hid_candidates = [6, 8, 10, 12, 14, 16, 18]`
- `n_timb_candidates = [4, 6, 8, 10, 12, 14, 16]`

Losses (`[loss, list([n_hid, n_timb])]`):
`[[12.756245229436063 list([6, 4])]
 [12.756556719198993 list([8, 4])]
 [12.757583793552442 list([8, 6])]
 [12.755354256465518 list([10, 4])]
 [12.756701239224139 list([10, 6])]
 [12.75628732264727 list([10, 8])]
 [12.75652725395115 list([12, 4])]
 [12.756516029094827 list([12, 6])]
 [12.757957020025144 list([12, 8])]
 [12.757127783764368 list([12, 10])]
 [12.75653426948635 list([14, 4])]
 [12.75579904139727 list([14, 6])]
 [12.757596421515805 list([14, 8])]
 [12.756250841864224 list([14, 10])]
 [12.757847577676007 list([14, 12])]
 [12.75629153196839 list([16, 4])]
 [12.75677841011135 list([16, 6])]
 [12.757703057650861 list([16, 8])]
 [12.756217167295258 list([16, 10])]
 [12.756746138649426 list([16, 12])]
 [12.757397180316092 list([16, 14])]
 [12.756252244971265 list([18, 4])]
 [12.755765366828305 list([18, 6])]
 [12.756218570402298 list([18, 8])]
 [12.757287737966953 list([18, 10])]
 [12.757718491828305 list([18, 12])]
 [12.75823904454023 list([18, 14])]
 [12.756389749461206 list([18, 16])]]`